### PR TITLE
Bootstrap/initialize muho stdlib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,14 @@
-.PHONY: all build clean check-lint lint doc utop dev-deps deps init-database
+.PHONY: all build clean check-lint lint doc utop dev-deps deps init-database test
 
 all: build
 
 # Compiles the libraries and binaries needed to start the server.
 build:
 	dune build
+
+# Run tests
+test:
+	dune runtest --no-buffer -j 1
 
 # Cleans up compilation artefacts
 clean:

--- a/lib/muho-stdlib/dune
+++ b/lib/muho-stdlib/dune
@@ -1,0 +1,5 @@
+(library
+ (name muho_stdlib)
+ (package muhokama)
+ (synopsis "Standard library for Muhokama")
+ (libraries preface))

--- a/lib/muho-stdlib/exn.ml
+++ b/lib/muho-stdlib/exn.ml
@@ -1,0 +1,133 @@
+type t = exn
+
+exception Unknown
+exception Unknown_with_message of string
+exception List of t list
+exception Required_field of string
+
+exception
+  Unexpected_value of
+    { expected_type : string
+    ; given_value : string
+    }
+
+exception
+  Int_too_large of
+    { given_value : int
+    ; max_bound : int
+    }
+
+exception
+  Int_too_small of
+    { given_value : int
+    ; min_bound : int
+    }
+
+exception String_is_empty
+exception String_is_blank of string
+
+exception
+  Invalid_field of
+    { key : string
+    ; errors : t Preface.Nonempty_list.t
+    }
+
+let rec equal a b =
+  match a, b with
+  | Unknown, Unknown -> true
+  | List list_a, List list_b -> List.equal equal list_a list_b
+  | Unknown_with_message msg_a, Unknown_with_message msg_b ->
+    String.equal msg_a msg_b
+  | Required_field field_a, Required_field field_b ->
+    String.equal field_a field_b
+  | Unexpected_value a, Unexpected_value b ->
+    String.equal a.expected_type b.expected_type
+    && String.equal a.given_value b.given_value
+  | Int_too_large a, Int_too_large b ->
+    Int.equal a.given_value b.given_value && Int.equal a.max_bound b.max_bound
+  | Int_too_small a, Int_too_small b ->
+    Int.equal a.given_value b.given_value && Int.equal a.min_bound b.min_bound
+  | String_is_blank a, String_is_blank b -> String.equal a b
+  | String_is_empty, String_is_empty -> true
+  | Invalid_field a, Invalid_field b ->
+    String.equal a.key b.key
+    && Preface.Nonempty_list.equal equal a.errors b.errors
+  | a, b -> Preface.Exn.equal a b
+;;
+
+let rec pp ppf =
+  let open Pp in
+  function
+  | Unknown_with_message message ->
+    branch_with (double_quoted string) message ppf "Unknown_with_message"
+  | List l -> branch_with (list pp) l ppf "List"
+  | Required_field f ->
+    branch_with (double_quoted string) f ppf "Required_field"
+  | Unexpected_value { given_value; expected_type } ->
+    branch_with
+      record
+      [ field "given_value" given_value (double_quoted string)
+      ; field "expected_type" expected_type (double_quoted string)
+      ]
+      ppf
+      "Unexpected_value"
+  | Int_too_large { given_value; max_bound } ->
+    branch_with
+      record
+      [ field "given_value" given_value int; field "max_bound" max_bound int ]
+      ppf
+      "Int_too_large"
+  | Int_too_small { given_value; min_bound } ->
+    branch_with
+      record
+      [ field "given_value" given_value int; field "min_bound" min_bound int ]
+      ppf
+      "Int_too_large"
+  | String_is_blank s ->
+    branch_with (double_quoted string) s ppf "String_is_blank"
+  | String_is_empty -> branch ppf "String_is_empty"
+  | Invalid_field { key; errors } ->
+    branch_with
+      record
+      [ field "key" key string
+      ; field "errors" errors @@ Preface.Nonempty_list.pp pp
+      ]
+      ppf
+      "Invalid_field"
+  | Unknown | _ -> branch ppf "Unknown"
+;;
+
+let pp_desc ppf = function
+  | Unknown_with_message message ->
+    Format.fprintf
+      ppf
+      {|An unknown, with message: "%s"  error appeared|}
+      message
+  | List _list -> Format.fprintf ppf "There Several errors were found"
+  | Required_field field ->
+    Format.fprintf ppf {|The field [%s] is required|} field
+  | Unexpected_value { given_value; expected_type } ->
+    Format.fprintf
+      ppf
+      "The value [%s] cannot be treated as [%s]"
+      given_value
+      expected_type
+  | Int_too_large { given_value; max_bound } ->
+    Format.fprintf ppf "The value [%d] is > [%d]" given_value max_bound
+  | Int_too_small { given_value; min_bound } ->
+    Format.fprintf ppf "The value [%d] is < [%d]" given_value min_bound
+  | String_is_blank s ->
+    Format.fprintf ppf "The string %a is blank" Pp.(double_quoted string) s
+  | String_is_empty -> Format.fprintf ppf "A given string is empty"
+  | Invalid_field { key; errors = _ } ->
+    Format.fprintf ppf "The field [%s] is invalid" key
+  | Unknown -> Format.fprintf ppf "An unknown error appeared"
+  | e -> Preface.Exn.pp ppf e
+;;
+
+let as_try exn = Preface.Try.error exn
+
+let as_validation exn =
+  let nel = Preface.Nonempty_list.create exn in
+  Preface.Validate.invalid nel
+;;

--- a/lib/muho-stdlib/exn.mli
+++ b/lib/muho-stdlib/exn.mli
@@ -1,0 +1,64 @@
+(** Describes the range of errors that can occur and provides helpers. *)
+
+(** {1 Types} *)
+
+(** [Exn.t] is an alias on [exn]. *)
+type t = exn
+
+(** {1 Exceptions}
+
+    All declared exceptions. *)
+
+(** An unknown exception.*)
+exception Unknown
+
+(** An unknown exception with a message attached. *)
+exception Unknown_with_message of string
+
+(** An error list (mainly to project Validation in Try).*)
+exception List of t list
+
+(** Error propagated when a required field is missing. *)
+exception Required_field of string
+
+(** Error propagated when a field is invalid. *)
+exception
+  Invalid_field of
+    { key : string
+    ; errors : t Preface.Nonempty_list.t
+    }
+
+(** Error propagated when a value cannot be projected into a type. *)
+exception
+  Unexpected_value of
+    { expected_type : string
+    ; given_value : string
+    }
+
+(** Error propagated when an integer is too large. *)
+exception
+  Int_too_large of
+    { given_value : int
+    ; max_bound : int
+    }
+
+(** Error propagated when an integer is too small. *)
+exception
+  Int_too_small of
+    { given_value : int
+    ; min_bound : int
+    }
+
+(** Propagated when a string is empty.*)
+exception String_is_empty
+
+(** Propagated when a string is blank.*)
+exception String_is_blank of string
+
+(** {1 Helpers} *)
+
+val equal : t -> t -> bool
+val pp : t Pp.t
+val pp_desc : t Pp.t
+val as_try : t -> 'a Preface.Try.t
+val as_validation : t -> 'a Preface.Validate.t

--- a/lib/muho-stdlib/pp.ml
+++ b/lib/muho-stdlib/pp.ml
@@ -1,0 +1,32 @@
+type 'a t = Format.formatter -> 'a -> unit
+type packed = E : ('a * 'a t) -> packed
+
+let pack value pp = E (value, pp)
+let string ppf = Format.fprintf ppf "%s"
+let int ppf = Format.fprintf ppf "%d"
+let double_quoted aux ppf x = Format.fprintf ppf {|"%a"|} aux x
+let simple_quoted aux ppf x = Format.fprintf ppf {|'%a'|} aux x
+let unit ppf () = Format.fprintf ppf "()"
+
+let rec pp_record_fields ppf = function
+  | [] -> ()
+  | (key, E (value, pp)) :: (_ :: _ as xs) ->
+    let () = Format.fprintf ppf "@[<v 1>%s =@ %a;@ @]" key pp value in
+    pp_record_fields ppf xs
+  | (key, E (value, pp)) :: xs ->
+    let () = Format.fprintf ppf "@[<v 1>%s =@ %a@]" key pp value in
+    pp_record_fields ppf xs
+;;
+
+let record ppf repr = Format.fprintf ppf "{ @[%a@] }" pp_record_fields repr
+let field key value pp = key, pack value pp
+let branch = string
+
+let branch_with pp x ppf constr =
+  Format.fprintf ppf "@[<1>%s@ @[%a@]@]" constr pp x
+;;
+
+let list pp ppf list =
+  let pp_sep ppf () = Format.fprintf ppf ";@ " in
+  Format.(fprintf ppf "@[[ %a ]@]" (pp_print_list ~pp_sep pp) list)
+;;

--- a/lib/muho-stdlib/pp.mli
+++ b/lib/muho-stdlib/pp.mli
@@ -1,0 +1,48 @@
+(** Help for handling complex printers. *)
+
+(** {1 Types} *)
+
+(** An alias for [Format.formatter -> 'a -> unit]. *)
+type 'a t = Format.formatter -> 'a -> unit
+
+(** A packed formatter. *)
+type packed
+
+(** {1 API} *)
+
+(** Pack a value with a formatter. *)
+val pack : 'a -> 'a t -> packed
+
+(** Print unit. *)
+val unit : unit t
+
+(** Print string. *)
+val string : string t
+
+(** Print int. *)
+val int : int t
+
+(** Print something with double quotes.*)
+val double_quoted : 'a t -> 'a t
+
+(** Print a list using [;] as a separator.*)
+val list : 'a t -> 'a list t
+
+(** Print something with simple quotes.*)
+val simple_quoted : 'a t -> 'a t
+
+(** {2 Print records} *)
+
+(** Group a field with a label. *)
+val field : string -> 'a -> 'a t -> string * packed
+
+(** Print a record field by fields. *)
+val record : (string * packed) list t
+
+(** {2 Print sums fragment} *)
+
+(** Print a simple constructor without argument. *)
+val branch : string t
+
+(** Print a simple constructor with arguments. *)
+val branch_with : 'a t -> 'a -> string t

--- a/lib/muho-stdlib/provider.ml
+++ b/lib/muho-stdlib/provider.ml
@@ -1,0 +1,93 @@
+type 'a field =
+  { validation : string option -> 'a Preface.Validate.t
+  ; key : string
+  }
+
+module Functor = Preface.Make.Functor.Via_map (struct
+  type 'a t = 'a field
+
+  let map f field =
+    let open Preface.Validate.Functor in
+    { field with validation = (fun x -> f <$> field.validation x) }
+  ;;
+end)
+
+include Preface.Make.Free_applicative.Over_functor (Functor)
+module Run = To_applicative (Preface.Validate.Applicative)
+
+let ( & ) f g = Preface.Validate.Monad.(f >=> g)
+
+let handle_errors key = function
+  | Preface.Validation.Valid x -> Preface.Validation.Valid x
+  | Preface.Validation.Invalid errors ->
+    let exn = Exn.(Invalid_field { key; errors }) in
+    Exn.as_validation exn
+;;
+
+let optional f key =
+  let validation =
+    let open Preface.Validate in
+    function
+    | None -> valid None
+    | Some value -> Functor.(Option.some <$> (f value |> handle_errors key))
+  in
+  promote { key; validation }
+;;
+
+let required f key =
+  let validation = function
+    | None -> Exn.(as_validation @@ Required_field key)
+    | Some value -> f value |> handle_errors key
+  in
+  promote { key; validation }
+;;
+
+let int x =
+  match int_of_string_opt x with
+  | None ->
+    Exn.(
+      as_validation
+      @@ Unexpected_value { expected_type = "int"; given_value = x })
+  | Some given_value -> Preface.Validate.valid given_value
+;;
+
+let string x = Preface.Validate.valid x
+
+let greater_than min_bound given_value =
+  if given_value > min_bound
+  then Preface.Validate.valid given_value
+  else Exn.(as_validation @@ Int_too_small { given_value; min_bound })
+;;
+
+let smaller_than max_bound given_value =
+  if given_value < max_bound
+  then Preface.Validate.valid given_value
+  else Exn.(as_validation @@ Int_too_large { given_value; max_bound })
+;;
+
+let bounded min_bound max_bound =
+  let min = Int.min min_bound max_bound
+  and max = Int.max min_bound max_bound in
+  greater_than (pred min) & smaller_than (succ max)
+;;
+
+let not_empty = function
+  | "" -> Exn.(as_validation String_is_empty)
+  | str -> Preface.Validate.valid str
+;;
+
+let not_blank given_value =
+  match String.trim given_value with
+  | "" -> Exn.(as_validation @@ String_is_blank given_value)
+  | _ -> Preface.Validate.valid given_value
+;;
+
+let run fetch validate =
+  Run.run
+    { transform =
+        (fun field ->
+          let r = fetch field.key in
+          field.validation r)
+    }
+    validate
+;;

--- a/lib/muho-stdlib/provider.mli
+++ b/lib/muho-stdlib/provider.mli
@@ -1,0 +1,50 @@
+(** Provider is a Free Applicative Functor that allows to read and validate data
+    from optional strings, validate them and project them into arbitrary
+    structures. For example to read environment variables. *)
+
+(** {1 Types} *)
+
+(** Describes a validatable field (the type embeds a key and a validation
+    function). *)
+type 'a field
+
+(** {1 Applicative API} *)
+
+include Preface.Specs.FREE_APPLICATIVE with type 'a f := 'a field (** @inline *)
+
+(** {1 Run Free Validation to Validation} *)
+
+module Run :
+  Preface.Specs.Free_applicative.TO_APPLICATIVE
+    with type 'a t := 'a t
+     and type 'a f := 'a field
+     and type 'a applicative := 'a Preface.Validate.t
+
+(** {1 Validation} *)
+
+val run : (string -> string option) -> 'a t -> 'a Preface.Validate.t
+
+(** {1 Field fetching} *)
+
+val optional : (string -> 'a Preface.Validate.t) -> string -> 'a option t
+val required : (string -> 'a Preface.Validate.t) -> string -> 'a t
+
+(** {1 Validator} *)
+
+(** Sequential composition of validator. *)
+val ( & )
+  :  ('a -> 'b Preface.Validate.t)
+  -> ('b -> 'c Preface.Validate.t)
+  -> 'a
+  -> 'c Preface.Validate.t
+
+val int : string -> int Preface.Validate.t
+val greater_than : int -> int -> int Preface.Validate.t
+val smaller_than : int -> int -> int Preface.Validate.t
+
+(** [bounded min max] is [greater_than (min - 1) & smaller_than (max + 1)]. *)
+val bounded : int -> int -> int -> int Preface.Validate.t
+
+val string : string -> string Preface.Validate.t
+val not_empty : string -> string Preface.Validate.t
+val not_blank : string -> string Preface.Validate.t

--- a/test/test-stdlib/dune
+++ b/test/test-stdlib/dune
@@ -1,0 +1,3 @@
+(test
+ (name muho_stdlib_test)
+ (libraries alcotest muho_stdlib muho_test_util))

--- a/test/test-stdlib/muho_stdlib_test.ml
+++ b/test/test-stdlib/muho_stdlib_test.ml
@@ -1,0 +1,1 @@
+let () = Alcotest.run "Muho_stdlib test" [ Provider_test.cases ]

--- a/test/test-stdlib/provider_test.ml
+++ b/test/test-stdlib/provider_test.ml
@@ -1,0 +1,385 @@
+open Muho_test_util
+open Muho_stdlib
+open Alcotest
+
+let test_int_validation_valid =
+  test
+    ~about:"int"
+    ~desc:
+      "When the given input is a valid int, it should parse it and wrap it \
+       into [valid]"
+    (fun () ->
+      let expected = Preface.Validate.valid 1678
+      and computed = Provider.int "1678" in
+      same (validate_testable int) ~computed ~expected)
+;;
+
+let test_int_validation_invalid =
+  test
+    ~about:"int"
+    ~desc:"When the given input is not a valid int, it should return an error"
+    (fun () ->
+      let given_value = "16-78"
+      and expected_type = "int" in
+      let expected =
+        Exn.(as_validation @@ Unexpected_value { given_value; expected_type })
+      and computed = Provider.int given_value in
+      same (validate_testable int) ~computed ~expected)
+;;
+
+let test_int_with_smaller_bound_valid =
+  test
+    ~about:"int & greater_than"
+    ~desc:
+      "When the given input is a valid int and greater than the given bound, \
+       it should parse it and wrap it into [valid]"
+    (fun () ->
+      let expected = Preface.Validate.valid 999
+      and computed = Provider.(int & greater_than 997) "999" in
+      same (validate_testable int) ~computed ~expected)
+;;
+
+let test_int_with_smaller_bound_invalid =
+  test
+    ~about:"int & greater_than"
+    ~desc:
+      "When the given input is a valid int and smaller than the given bound, \
+       it should parse it should return an error"
+    (fun () ->
+      let given_value = 9
+      and min_bound = 997 in
+      let expected =
+        Exn.(as_validation @@ Int_too_small { given_value; min_bound })
+      and computed =
+        Provider.(int & greater_than min_bound) @@ string_of_int given_value
+      in
+      same (validate_testable int) ~computed ~expected)
+;;
+
+let test_int_with_smaller_bound_invalid_because_of_int =
+  test
+    ~about:"int & greater_than"
+    ~desc:
+      "When the given input is not a valid int, even with greater flag it \
+       should return an error"
+    (fun () ->
+      let given_value = "16-78"
+      and expected_type = "int" in
+      let expected =
+        Exn.(as_validation @@ Unexpected_value { given_value; expected_type })
+      and computed = Provider.(int & greater_than 999) given_value in
+      same (validate_testable int) ~computed ~expected)
+;;
+
+let test_int_with_greater_bound_valid =
+  test
+    ~about:"int & smaller_than"
+    ~desc:
+      "When the given input is a valid int and greater than the given bound, \
+       it should parse it and wrap it into [valid]"
+    (fun () ->
+      let expected = Preface.Validate.valid 996
+      and computed = Provider.(int & smaller_than 997) "996" in
+      same (validate_testable int) ~computed ~expected)
+;;
+
+let test_int_with_greater_bound_invalid =
+  test
+    ~about:"int & smaller_than"
+    ~desc:
+      "When the given input is a valid int and greater than the given bound, \
+       it should parse it should return an error"
+    (fun () ->
+      let given_value = 9999
+      and max_bound = 997 in
+      let expected =
+        Exn.(as_validation @@ Int_too_large { given_value; max_bound })
+      and computed =
+        Provider.(int & smaller_than max_bound) @@ string_of_int given_value
+      in
+      same (validate_testable int) ~computed ~expected)
+;;
+
+let test_int_with_greater_bound_invalid_because_of_int =
+  test
+    ~about:"int & smaller_than"
+    ~desc:
+      "When the given input is not a valid int, even with smaller flag it \
+       should return an error"
+    (fun () ->
+      let given_value = "16-78"
+      and expected_type = "int" in
+      let expected =
+        Exn.(as_validation @@ Unexpected_value { given_value; expected_type })
+      and computed = Provider.(int & smaller_than 999) given_value in
+      same (validate_testable int) ~computed ~expected)
+;;
+
+let test_int_with_bound_valid =
+  test
+    ~about:"int & bounded"
+    ~desc:
+      "When the given input is a valid int and included in the given range, it \
+       should parse it and wrap it into [valid]"
+    (fun () ->
+      let expected = Preface.Validate.valid 996
+      and computed = Provider.(int & bounded 100 1000) "996" in
+      same (validate_testable int) ~computed ~expected)
+;;
+
+let test_int_with_bound_invalid =
+  test
+    ~about:"int & bounded"
+    ~desc:
+      "When the given input is a valid int and greater than the max bound, it \
+       should parse it should return an error"
+    (fun () ->
+      let given_value = 9999
+      and max_bound = 997 in
+      let expected =
+        Exn.(
+          as_validation
+          @@ Int_too_large { given_value; max_bound = succ max_bound })
+      and computed =
+        Provider.(int & bounded max_bound 0) @@ string_of_int given_value
+      in
+      same (validate_testable int) ~computed ~expected)
+;;
+
+let test_int_with_bound_invalid_because_of_smaller =
+  test
+    ~about:"int & bounded"
+    ~desc:
+      "When the given input is a valid int and smaller than the min bound, it \
+       should parse it should return an error"
+    (fun () ->
+      let given_value = 100
+      and min_bound = 997 in
+      let expected =
+        Exn.(
+          as_validation
+          @@ Int_too_small { given_value; min_bound = pred min_bound })
+      and computed =
+        Provider.(int & bounded min_bound 1000) @@ string_of_int given_value
+      in
+      same (validate_testable int) ~computed ~expected)
+;;
+
+let test_int_with_bound_invalid_because_of_int =
+  test
+    ~about:"int & bounded"
+    ~desc:
+      "When the given input is not a valid int, even with greater flag it \
+       should return an error"
+    (fun () ->
+      let given_value = "16-78"
+      and expected_type = "int" in
+      let expected =
+        Exn.(as_validation @@ Unexpected_value { given_value; expected_type })
+      and computed = Provider.(int & bounded 0 999) given_value in
+      same (validate_testable int) ~computed ~expected)
+;;
+
+let test_string_not_empty_valid =
+  test
+    ~about:"string & not_empty"
+    ~desc:
+      "When the string is not empty it should return it wrapped into [valid]"
+    (fun () ->
+      let expected = Preface.Validate.valid "ok"
+      and computed = Provider.(string & not_empty) "ok" in
+      same (validate_testable string) ~computed ~expected)
+;;
+
+let test_string_not_empty_valid_even_blank =
+  test
+    ~about:"string & not_empty"
+    ~desc:
+      "When the string is not empty (but blank) it should return it wrapped \
+       into [valid]"
+    (fun () ->
+      let expected = Preface.Validate.valid "    "
+      and computed = Provider.(string & not_empty) "    " in
+      same (validate_testable string) ~computed ~expected)
+;;
+
+let test_string_not_empty_invalid =
+  test
+    ~about:"string & not_empty"
+    ~desc:"When the string is empty it should return an error"
+    (fun () ->
+      let expected = Exn.(as_validation String_is_empty)
+      and computed = Provider.(string & not_empty) "" in
+      same (validate_testable string) ~computed ~expected)
+;;
+
+let test_string_not_blank_valid =
+  test
+    ~about:"string & not_blank"
+    ~desc:
+      "When the string is not blank it should return it wrapped into [valid]"
+    (fun () ->
+      let expected = Preface.Validate.valid "ok"
+      and computed = Provider.(string & not_blank) "ok" in
+      same (validate_testable string) ~computed ~expected)
+;;
+
+let test_string_not_blank_invalid =
+  test
+    ~about:"string & not_blank"
+    ~desc:"When the string is blank it should return an error"
+    (fun () ->
+      let expected = Exn.(as_validation @@ String_is_blank "      ")
+      and computed = Provider.(string & not_blank) "      " in
+      same (validate_testable string) ~computed ~expected)
+;;
+
+module User = struct
+  module Store = Map.Make (String)
+
+  type t =
+    { id : string
+    ; age : int option
+    ; name : string option
+    ; email : string
+    }
+
+  let pp ppf { id; age; name; email } =
+    Pp.(
+      record
+        ppf
+        [ field "id" id string
+        ; field "age" age @@ Preface.Option.pp int
+        ; field "name" name @@ Preface.Option.pp string
+        ; field "email" email string
+        ])
+  ;;
+
+  let equal a b =
+    String.equal a.id b.id
+    && Option.equal Int.equal a.age b.age
+    && Option.equal String.equal a.name b.name
+    && String.equal a.email b.email
+  ;;
+
+  let testable = Alcotest.testable pp equal
+  let mk id age name email = { id; age; name; email }
+
+  let validate =
+    let open Provider in
+    mk
+    <$> required string "id"
+    <*> optional (int & greater_than 7 & smaller_than 120) "age"
+    <*> optional (string & not_blank) "name"
+    <*> required (string & not_blank) "email"
+  ;;
+
+  let run store = Provider.run (fun key -> Store.find_opt key store) validate
+
+  let store list =
+    List.fold_left (fun s (k, v) -> Store.add k v s) Store.empty list
+  ;;
+end
+
+let test_user_when_every_data_are_filled =
+  test
+    ~about:"Provider.run"
+    ~desc:"When all data are given, it should wrap an user into [valid]"
+    (fun () ->
+      let store =
+        User.store
+          [ "id", "xvw"
+          ; "age", "32"
+          ; "name", "Vdw"
+          ; "email", "xavier@mail.com"
+          ]
+      in
+      let expected =
+        Preface.Validate.valid
+        @@ User.mk "xvw" (Some 32) (Some "Vdw") "xavier@mail.com"
+      and computed = User.run store in
+      same (validate_testable User.testable) ~expected ~computed)
+;;
+
+let test_user_when_some_data_are_filled =
+  test
+    ~about:"Provider.run"
+    ~desc:
+      "When all required data are given, it should wrap an user into [valid]"
+    (fun () ->
+      let store = User.store [ "id", "xvw"; "email", "xavier@mail.com" ] in
+      let expected =
+        Preface.Validate.valid @@ User.mk "xvw" None None "xavier@mail.com"
+      and computed = User.run store in
+      same (validate_testable User.testable) ~expected ~computed)
+;;
+
+let test_user_when_all_data_are_missing =
+  test
+    ~about:"Provider.run"
+    ~desc:"When all required data are missing, it should return an error"
+    (fun () ->
+      let store =
+        User.store [ "an_id", "xvw"; "an_email", "xavier@mail.com" ]
+      in
+      let expected =
+        Exn.(errors (Required_field "email") [ Required_field "id" ])
+      and computed = User.run store in
+      same (validate_testable User.testable) ~expected ~computed)
+;;
+
+let test_user_when_there_is_some_errors =
+  test
+    ~about:"Provider.run"
+    ~desc:"When there is errors, it should return an error"
+    (fun () ->
+      let store =
+        User.store
+          [ "an_id", "xvw"
+          ; "an_email", "xavier@mail.com"
+          ; "age", "-12"
+          ; "name", "   "
+          ]
+      in
+      let expected =
+        Exn.(
+          errors
+            (Required_field "email")
+            [ Invalid_field
+                { key = "name"; errors = nel (String_is_blank "   ") [] }
+            ; Invalid_field
+                { key = "age"
+                ; errors =
+                    nel (Int_too_small { given_value = -12; min_bound = 7 }) []
+                }
+            ; Required_field "id"
+            ])
+      and computed = User.run store in
+      same (validate_testable User.testable) ~expected ~computed)
+;;
+
+let cases =
+  ( "Provider"
+  , [ test_int_validation_valid
+    ; test_int_validation_invalid
+    ; test_int_with_smaller_bound_valid
+    ; test_int_with_smaller_bound_invalid
+    ; test_int_with_smaller_bound_invalid_because_of_int
+    ; test_int_with_greater_bound_valid
+    ; test_int_with_greater_bound_invalid
+    ; test_int_with_greater_bound_invalid_because_of_int
+    ; test_int_with_bound_valid
+    ; test_int_with_bound_invalid
+    ; test_int_with_bound_invalid_because_of_int
+    ; test_int_with_bound_invalid_because_of_smaller
+    ; test_string_not_empty_valid
+    ; test_string_not_empty_invalid
+    ; test_string_not_empty_valid_even_blank
+    ; test_string_not_blank_valid
+    ; test_string_not_blank_invalid
+    ; test_user_when_every_data_are_filled
+    ; test_user_when_some_data_are_filled
+    ; test_user_when_all_data_are_missing
+    ; test_user_when_there_is_some_errors
+    ] )
+;;

--- a/test/test-stdlib/provider_test.mli
+++ b/test/test-stdlib/provider_test.mli
@@ -1,0 +1,1 @@
+val cases : string * unit Alcotest.test_case list

--- a/test/test-util/dune
+++ b/test/test-util/dune
@@ -1,0 +1,4 @@
+(library
+ (name muho_test_util)
+ (package muhokama)
+ (libraries preface alcotest muho_stdlib))

--- a/test/test-util/muho_test_util.ml
+++ b/test/test-util/muho_test_util.ml
@@ -1,0 +1,28 @@
+let test ?(speed = `Quick) ~about ~desc f =
+  Alcotest.test_case (Format.asprintf "%-42s%s" about desc) speed f
+;;
+
+let same testable ~expected ~computed =
+  Alcotest.check testable "should be same" expected computed
+;;
+
+let exn_testable = Alcotest.testable Muho_stdlib.Exn.pp Muho_stdlib.Exn.equal
+
+let validate_testable t =
+  let ppx = Alcotest.pp t
+  and eqx = Alcotest.equal t in
+  Alcotest.testable
+    (Preface.Validation.pp ppx (Preface.Nonempty_list.pp Muho_stdlib.Exn.pp))
+    (Preface.Validation.equal
+       eqx
+       (Preface.Nonempty_list.equal Muho_stdlib.Exn.equal))
+;;
+
+let nel x xs =
+  let open Preface.Nonempty_list in
+  match from_list xs with
+  | None -> Last x
+  | Some xs -> x :: xs
+;;
+
+let errors x xs = nel x xs |> Preface.Validate.invalid

--- a/test/test-util/muho_test_util.mli
+++ b/test/test-util/muho_test_util.mli
@@ -1,0 +1,27 @@
+(** An helper for test definition.*)
+val test
+  :  ?speed:Alcotest.speed_level
+  -> about:string
+  -> desc:string
+  -> ('a -> unit)
+  -> 'a Alcotest.test_case
+
+(** An helper for checking equalities.*)
+val same : 'a Alcotest.testable -> expected:'a -> computed:'a -> unit
+
+(** Helper for creating Nonempty list. *)
+val nel : 'a -> 'a list -> 'a Preface.Nonempty_list.t
+
+(** Helper for creating error side of validation. *)
+val errors
+  :  Muho_stdlib.Exn.t
+  -> Muho_stdlib.Exn.t list
+  -> 'a Preface.Validate.t
+
+(** {1 Testables}*)
+
+val exn_testable : Muho_stdlib.Exn.t Alcotest.testable
+
+val validate_testable
+  :  'a Alcotest.testable
+  -> 'a Preface.Validate.t Alcotest.testable


### PR DESCRIPTION
This patch initiates a standard library to develop the various binaries needed to build the forum.

Exn: As Preface uses (for [Try] and [Validate]) biased versions with
exceptions to describe an error, all exceptions propagated in the
project are centralised in a module [Exn] which provides equalities and
pretty-printing functions.

Pp: Some small helpers for formatter/pretty printer

Provider: Describes a uniform way of querying a key value environment
and applying validation.
