### PR TITLE
Add docker image build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.github
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM ocaml/opam:alpine-ocaml-4.14 as builder
+
+RUN opam repo add opam git+https://github.com/ocaml/opam-repository
+RUN opam install dune
+
+USER root
+RUN apk add --no-cache libev-dev gmp-dev pkgconfig libpq-dev libressl-dev
+
+USER opam
+
+COPY --chown=opam muhokama.opam /build/muhokama.opam
+
+RUN cd /build && opam install . --deps-only --with-test -y
+
+COPY --chown=opam . /build/
+
+RUN cd /build && opam exec -- dune build
+
+FROM alpine:3 as final
+
+RUN apk add --no-cache libev-dev gmp-dev libpq-dev libressl-dev
+
+ENV LOG_LEVEL=info
+ENV PGSQL_CONNECTION_POOL=20
+
+EXPOSE 4000
+
+WORKDIR /app
+
+ADD assets /app/assets
+ADD migrations /app/migrations
+
+COPY --from=builder /build/bin/muhokama.exe /usr/bin/muhokama.exe
+
+ENTRYPOINT [ "muhokama.exe" ]
+CMD [ "server.launch" ]

--- a/app/app.ml
+++ b/app/app.ml
@@ -8,7 +8,7 @@ let sql_pool env =
 ;;
 
 let run ~port env =
-  Dream.run ~port
+  Dream.run ~port ~interface:"0.0.0.0"
   @@ Dream.logger
   @@ sql_pool env
   @@ Dream.sql_sessions


### PR DESCRIPTION
Define a multistage build to build as a static binary using musl and a docker image based on alpine to tun the static binary with only assets and migrations

Docker image by default run server.launch command but can execute other commands in the form `docker run ... <image_tag> db.migration`

Modify adress interface listened by http server to 0.0.0.0 to serve request in container