### PR TITLE
A page which list all categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,5 +78,5 @@ subcommand can display its `man` page using the `--help` flag.
 | `./bin/muhokama.exe db.migrate --to N` | Replaces the migration state according to the given parameter `N`. If for example the current state is `5`, `./bin/muhokama.exe db.migrate --to 2` will play `5.down`, `4.down` and `3.down`. If, on the other hand, the current state is `0`, `1.up`, and `2.up` will be played. If no error has occurred, the state must be the argument given to `--to`. |
 | `./bin/muhokama.exe db.migrate.reset` | Removes the migration context (in database). . |
 | `./bin/muhokama.exe server.launch`| Starts the application on the default port (`4000`). It is possible to add the `--port X` flag to change this value. |
-| `.bin/muhokama.exe user.list` | Lists all registered users (regardless of their status) |
-| `.bin/muhokama.exe user.set-state -U USER_ID -S USER_STATE` | Changes the status (`inactive`, ` member`,  `moderator` `admin`) of a user via its ID ( `UUID` ). |
+| `./bin/muhokama.exe user.list` | Lists all registered users (regardless of their status) |
+| `./bin/muhokama.exe user.set-state -U USER_ID -S USER_STATE` | Changes the status (`inactive`, ` member`,  `moderator` `admin`) of a user via its ID ( `UUID` ). |

--- a/app/endpoints/category_endpoints.ml
+++ b/app/endpoints/category_endpoints.ml
@@ -1,0 +1,3 @@
+open Lib_service.Endpoint
+
+let list () = get (~/"category" / "list")

--- a/app/endpoints/endpoints.mli
+++ b/app/endpoints/endpoints.mli
@@ -6,3 +6,4 @@ module Global = Global_endpoints
 module User = User_endpoints
 module Topic = Topic_endpoints
 module Admin = Admin_endpoints
+module Category = Category_endpoints

--- a/app/models/topic_model.ml
+++ b/app/models/topic_model.ml
@@ -160,6 +160,25 @@ let count =
   fun (module Db : Lib_db.T) -> Lib_db.try_ @@ Db.find query ()
 ;;
 
+let count_by_categories =
+  let query =
+    (unit ->* (tup3 string string int)) {sql|
+      SELECT 
+        category_name,
+        category_description, 
+        COUNT(*)
+      FROM topics AS t
+        INNER JOIN categories AS c ON t.category_id = c.category_id
+      GROUP BY c.category_name, c.category_description
+      ORDER BY c.category_name
+    |sql}
+  in
+  fun (module Db : Lib_db.T) ->
+    let open Lwt_util in
+    let+? list = Lib_db.try_ @@ Db.collect_list query () in
+    list
+;;
+
 let create =
   let query =
     (tup4 string string string string ->! string)

--- a/app/models/topic_model.mli
+++ b/app/models/topic_model.mli
@@ -49,6 +49,9 @@ type creation_form
 (** Count the number of saved topics. *)
 val count : Lib_db.t -> int Try.t Lwt.t
 
+(** Count the number of saved topics grouped by category. *)
+val count_by_categories : Lib_db.t -> (string * string * int) list Try.t Lwt.t
+
 (** Create a new topic. *)
 val create : User_model.t -> creation_form -> Lib_db.t -> string Try.t Lwt.t
 

--- a/app/router.ml
+++ b/app/router.ml
@@ -25,7 +25,7 @@ let choose_service next_handler request =
     ; Services.Admin.new_category
     ; Services.Global.error
     ; Services.Global.root
-    ; Services.Category.list_
+    ; Services.Category.list
     ]
     next_handler
     request

--- a/app/router.ml
+++ b/app/router.ml
@@ -25,7 +25,7 @@ let choose_service next_handler request =
     ; Services.Admin.new_category
     ; Services.Global.error
     ; Services.Global.root
-    ; Services.Category.list
+    ; Services.Category.topics_count_by_categories
     ]
     next_handler
     request

--- a/app/router.ml
+++ b/app/router.ml
@@ -25,6 +25,7 @@ let choose_service next_handler request =
     ; Services.Admin.new_category
     ; Services.Global.error
     ; Services.Global.root
+    ; Services.Category.list_
     ]
     next_handler
     request

--- a/app/services/category_services.ml
+++ b/app/services/category_services.ml
@@ -3,7 +3,7 @@ open Lib_service
 open Util
 open Middlewares
 
-let list_ =
+let list =
   Service.failable_with
     ~:Endpoints.Category.list
     [user_authenticated]

--- a/app/services/category_services.ml
+++ b/app/services/category_services.ml
@@ -14,7 +14,7 @@ let topics_count_by_categories =
       user, count_topics_by_categories)
     ~succeed:(fun (user, count_topics_by_categories) request ->
       let flash_info = Util.Flash_info.fetch request in
-      let view = Views.Category.categories_by_topics_count ?flash_info ~user:user count_topics_by_categories in
+      let view = Views.Category.by_topics_count ?flash_info ~user:user count_topics_by_categories in
       Dream.html @@ from_tyxml view)
     ~failure:(fun err request ->
       Flash_info.error_tree request err;

--- a/app/services/category_services.ml
+++ b/app/services/category_services.ml
@@ -1,0 +1,21 @@
+open Lib_common
+open Lib_service
+open Util
+open Middlewares
+
+let list_ =
+  Service.failable_with
+    ~:Endpoints.Category.list
+    [user_authenticated]
+    ~attached:user_required
+    (fun user request ->
+      let open Lwt_util in
+      let+? categories = Dream.sql request @@ Models.Category.list Fun.id in
+      user, categories)
+    ~succeed:(fun (user, categories) request ->
+      let flash_info = Util.Flash_info.fetch request in
+      let view = Views.Category.categories ?flash_info categories ~user:user in
+      Dream.html @@ from_tyxml view)
+    ~failure:(fun err request ->
+      Flash_info.error_tree request err;
+      redirect_to ~:Endpoints.Global.root request)

--- a/app/services/category_services.ml
+++ b/app/services/category_services.ml
@@ -3,18 +3,18 @@ open Lib_service
 open Util
 open Middlewares
 
-let list =
+let topics_count_by_categories =
   Service.failable_with
     ~:Endpoints.Category.list
     [user_authenticated]
     ~attached:user_required
     (fun user request ->
       let open Lwt_util in
-      let+? categories = Dream.sql request @@ Models.Category.list Fun.id in
-      user, categories)
-    ~succeed:(fun (user, categories) request ->
+      let+? count_topics_by_categories = Dream.sql request @@ Models.Topic.count_by_categories in
+      user, count_topics_by_categories)
+    ~succeed:(fun (user, count_topics_by_categories) request ->
       let flash_info = Util.Flash_info.fetch request in
-      let view = Views.Category.categories ?flash_info categories ~user:user in
+      let view = Views.Category.categories_by_topics_count ?flash_info ~user:user count_topics_by_categories in
       Dream.html @@ from_tyxml view)
     ~failure:(fun err request ->
       Flash_info.error_tree request err;

--- a/app/services/category_services.mli
+++ b/app/services/category_services.mli
@@ -1,4 +1,4 @@
 open Lib_service
 
 (** Provide a page which list all available categories for users *)
-val list : (Dream.request, Dream.response) Service.t
+val topics_count_by_categories : (Dream.request, Dream.response) Service.t

--- a/app/services/category_services.mli
+++ b/app/services/category_services.mli
@@ -1,4 +1,4 @@
 open Lib_service
 
-(** Provide a page which list all available categories for users **)
+(** Provide a page which list all available categories for users *)
 val list : (Dream.request, Dream.response) Service.t

--- a/app/services/category_services.mli
+++ b/app/services/category_services.mli
@@ -1,0 +1,4 @@
+open Lib_service
+
+(** Provide a page which list all available categories for users **)
+val list : (Dream.request, Dream.response) Service.t

--- a/app/services/services.mli
+++ b/app/services/services.mli
@@ -6,3 +6,4 @@ module Global = Global_services
 module User = User_services
 module Topic = Topic_services
 module Admin = Admin_services
+module Category = Category_services

--- a/app/templates/component.ml
+++ b/app/templates/component.ml
@@ -102,7 +102,7 @@ let connected_navbar user =
             ; Util.a
                 ~a:[ a_class ["navbar-item"] ]
                 ~:Endpoints.Category.list
-                [ txt "Liste des categories" ]
+                [ txt "Catégories" ]
             ]
         ; div
             ~a:[ a_class [ "navbar-end" ] ]

--- a/app/templates/component.ml
+++ b/app/templates/component.ml
@@ -99,6 +99,10 @@ let connected_navbar user =
                 ~a:[ a_class [ "navbar-item" ] ]
                 ~:Endpoints.Topic.create
                 [ txt "Créer un fil de conversation" ]
+            ; Util.a
+                ~a:[ a_class ["navbar-item"] ]
+                ~:Endpoints.Category.list
+                [ txt "Liste des categories" ]
             ]
         ; div
             ~a:[ a_class [ "navbar-end" ] ]

--- a/app/views/admin_views.ml
+++ b/app/views/admin_views.ml
@@ -1,4 +1,5 @@
 open Lib_service
+open Category_views
 
 module List_moderable = struct
   let upgrade_btn =
@@ -78,109 +79,6 @@ module List_moderable = struct
         ]
       ~thead:hd
     @@ List.map (user_line csrf) users
-  ;;
-end
-
-module Category = struct
-  let category_name_input =
-    let open Tyxml.Html in
-    div
-      ~a:[ a_class [ "field" ] ]
-      [ label
-          ~a:[ a_class [ "label" ]; a_label_for "create_category_name" ]
-          [ txt "Nom de la catégorie" ]
-      ; div
-          ~a:[ a_class [ "control" ] ]
-          [ input
-              ~a:
-                [ a_input_type `Text
-                ; a_placeholder "programmation"
-                ; a_id "create_category_name"
-                ; a_name "category_name"
-                ; a_class [ "input" ]
-                ]
-              ()
-          ]
-      ; p
-          ~a:[ a_class [ "help" ] ]
-          [ txt
-              "Nom de la catégorie, choisissez quelque chose de concis mais \
-               clair !"
-          ]
-      ]
-  ;;
-
-  let category_description_input =
-    let open Tyxml.Html in
-    div
-      ~a:[ a_class [ "field" ] ]
-      [ label
-          ~a:[ a_class [ "label" ]; a_label_for "create_category_description" ]
-          [ txt "Description de la catégorie" ]
-      ; div
-          ~a:[ a_class [ "control" ] ]
-          [ textarea
-              ~a:
-                [ a_placeholder
-                    "Catégorie relative aux conversations concernant la \
-                     programmation"
-                ; a_id "create_category_description"
-                ; a_name "category_description"
-                ; a_class [ "textarea"; "is-small" ]
-                ]
-              (txt "")
-          ]
-      ; p
-          ~a:[ a_class [ "help" ] ]
-          [ txt "Choisissez une description concise mais claire !" ]
-      ]
-  ;;
-
-  let submit_button =
-    let open Tyxml.Html in
-    div
-      ~a:[ a_class [ "field" ] ]
-      [ div
-          ~a:[ a_class [ "control" ] ]
-          [ input
-              ~a:
-                [ a_input_type `Submit
-                ; a_value "Valider !"
-                ; a_class [ "button"; "is-link" ]
-                ]
-              ()
-          ]
-      ]
-  ;;
-
-  let creation_form csrf_token =
-    Templates.Util.form
-      ~:Endpoints.Admin.new_category
-      ~csrf_token
-      [ category_name_input; category_description_input; submit_button ]
-  ;;
-
-  let category_line category =
-    let open Tyxml.Html in
-    let open Models.Category in
-    tr [ td [ txt category.name ]; td [ txt category.description ] ]
-  ;;
-
-  let all categories =
-    let open Tyxml.Html in
-    let hd = thead [ tr [ th [ txt "Nom" ]; th [ txt "Description" ] ] ] in
-    table
-      ~a:
-        [ a_class
-            [ "table"
-            ; "is-fullwidth"
-            ; "is-narrow"
-            ; "is-striped"
-            ; "is-bordered"
-            ]
-        ]
-      ~thead:hd
-    @@ List.map category_line categories
   ;;
 end
 

--- a/app/views/admin_views.ml
+++ b/app/views/admin_views.ml
@@ -152,14 +152,14 @@ let categories ?flash_info ~csrf_token ?user categories =
                   [ h2
                       ~a:[ a_class [ "title"; "is-4" ] ]
                       [ txt "Catégories existantes" ]
-                  ; Category.all categories
+                  ; all categories
                   ]
               ]
           ; div
               [ h2
                   ~a:[ a_class [ "title"; "is-4" ] ]
                   [ txt "Créer une nouvelle catégorie" ]
-              ; Category.creation_form csrf_token
+              ; creation_form csrf_token
               ]
           ]
       ]

--- a/app/views/category_views.ml
+++ b/app/views/category_views.ml
@@ -1,107 +1,105 @@
 open Lib_service
 
-module Category = struct
-  let category_name_input =
-    let open Tyxml.Html in
-    div
-      ~a:[ a_class [ "field" ] ]
-      [ label
-          ~a:[ a_class [ "label" ]; a_label_for "create_category_name" ]
-          [ txt "Nom de la catégorie" ]
-      ; div
-          ~a:[ a_class [ "control" ] ]
-          [ input
-              ~a:
-                [ a_input_type `Text
-                ; a_placeholder "programmation"
-                ; a_id "create_category_name"
-                ; a_name "category_name"
-                ; a_class [ "input" ]
-                ]
-              ()
-          ]
-      ; p
-          ~a:[ a_class [ "help" ] ]
-          [ txt
-              "Nom de la catégorie, choisissez quelque chose de concis mais \
-               clair !"
-          ]
-      ]
-  ;;
-
-  let category_description_input =
-    let open Tyxml.Html in
-    div
-      ~a:[ a_class [ "field" ] ]
-      [ label
-          ~a:[ a_class [ "label" ]; a_label_for "create_category_description" ]
-          [ txt "Description de la catégorie" ]
-      ; div
-          ~a:[ a_class [ "control" ] ]
-          [ textarea
-              ~a:
-                [ a_placeholder
-                    "Catégorie relative aux conversations concernant la \
-                     programmation"
-                ; a_id "create_category_description"
-                ; a_name "category_description"
-                ; a_class [ "textarea"; "is-small" ]
-                ]
-              (txt "")
-          ]
-      ; p
-          ~a:[ a_class [ "help" ] ]
-          [ txt "Choisissez une description concise mais claire !" ]
-      ]
-  ;;
-
-  let submit_button =
-    let open Tyxml.Html in
-    div
-      ~a:[ a_class [ "field" ] ]
-      [ div
-          ~a:[ a_class [ "control" ] ]
-          [ input
-              ~a:
-                [ a_input_type `Submit
-                ; a_value "Valider !"
-                ; a_class [ "button"; "is-link" ]
-                ]
-              ()
-          ]
-      ]
-  ;;
-
-  let creation_form csrf_token =
-    Templates.Util.form
-      ~:Endpoints.Admin.new_category
-      ~csrf_token
-      [ category_name_input; category_description_input; submit_button ]
-  ;;
-
-  let category_line category =
-    let open Tyxml.Html in
-    let open Models.Category in
-    tr [ td [ txt category.name ]; td [ txt category.description ] ]
-  ;;
-
-  let all categories =
-    let open Tyxml.Html in
-    let hd = thead [ tr [ th [ txt "Nom" ]; th [ txt "Description" ] ] ] in
-    table
-      ~a:
-        [ a_class
-            [ "table"
-            ; "is-fullwidth"
-            ; "is-narrow"
-            ; "is-striped"
-            ; "is-bordered"
-            ]
+let category_name_input =
+  let open Tyxml.Html in
+  div
+    ~a:[ a_class [ "field" ] ]
+    [ label
+        ~a:[ a_class [ "label" ]; a_label_for "create_category_name" ]
+        [ txt "Nom de la catégorie" ]
+    ; div
+        ~a:[ a_class [ "control" ] ]
+        [ input
+            ~a:
+              [ a_input_type `Text
+              ; a_placeholder "programmation"
+              ; a_id "create_category_name"
+              ; a_name "category_name"
+              ; a_class [ "input" ]
+              ]
+            ()
         ]
-      ~thead:hd
-    @@ List.map category_line categories
-  ;;
-end
+    ; p
+        ~a:[ a_class [ "help" ] ]
+        [ txt
+            "Nom de la catégorie, choisissez quelque chose de concis mais \
+              clair !"
+        ]
+    ]
+;;
+
+let category_description_input =
+  let open Tyxml.Html in
+  div
+    ~a:[ a_class [ "field" ] ]
+    [ label
+        ~a:[ a_class [ "label" ]; a_label_for "create_category_description" ]
+        [ txt "Description de la catégorie" ]
+    ; div
+        ~a:[ a_class [ "control" ] ]
+        [ textarea
+            ~a:
+              [ a_placeholder
+                  "Catégorie relative aux conversations concernant la \
+                    programmation"
+              ; a_id "create_category_description"
+              ; a_name "category_description"
+              ; a_class [ "textarea"; "is-small" ]
+              ]
+            (txt "")
+        ]
+    ; p
+        ~a:[ a_class [ "help" ] ]
+        [ txt "Choisissez une description concise mais claire !" ]
+    ]
+;;
+
+let submit_button =
+  let open Tyxml.Html in
+  div
+    ~a:[ a_class [ "field" ] ]
+    [ div
+        ~a:[ a_class [ "control" ] ]
+        [ input
+            ~a:
+              [ a_input_type `Submit
+              ; a_value "Valider !"
+              ; a_class [ "button"; "is-link" ]
+              ]
+            ()
+        ]
+    ]
+;;
+
+let creation_form csrf_token =
+  Templates.Util.form
+    ~:Endpoints.Admin.new_category
+    ~csrf_token
+    [ category_name_input; category_description_input; submit_button ]
+;;
+
+let category_line category =
+  let open Tyxml.Html in
+  let open Models.Category in
+  tr [ td [ txt category.name ]; td [ txt category.description ] ]
+;;
+
+let all categories =
+  let open Tyxml.Html in
+  let hd = thead [ tr [ th [ txt "Nom" ]; th [ txt "Description" ] ] ] in
+  table
+    ~a:
+      [ a_class
+          [ "table"
+          ; "is-fullwidth"
+          ; "is-narrow"
+          ; "is-striped"
+          ; "is-bordered"
+          ]
+      ]
+    ~thead:hd
+  @@ List.map category_line categories
+;;
 
 let categories ?flash_info ?user categories =
     Templates.Layout.default
@@ -118,9 +116,49 @@ let categories ?flash_info ?user categories =
                   [ h2
                       ~a:[ a_class [ "title"; "is-4" ] ]
                       [ txt "Catégories existantes" ]
-                  ; Category.all categories
+                  ; all categories
                   ]
               ]
           ]
       ]
 ;;
+
+let category_topics_count_line cnt_topic_by_category =
+  let (category_name,category_descr,topic_cnt) = cnt_topic_by_category in
+  let open Tyxml.Html in
+  tr [ 
+    td [ 
+      p ~a:[a_class ["title is-4"]] [ txt category_name ];
+      p ~a:[a_class ["subtitle"]] [ txt category_descr ]
+    ]; 
+    td [
+    if topic_cnt > 0 then
+        Templates.Util.a 
+          ~:Endpoints.Topic.by_category [txt (string_of_int topic_cnt)] category_name
+    else
+      txt (string_of_int topic_cnt)
+    ]
+  ]
+
+
+
+let categories_by_topics_count ?flash_info ?user cnt_topics_by_categories =
+  let open Tyxml.Html in
+  let hd = thead [ tr [ th [ txt "Catégories" ]; th [ txt "Nombre de topics" ] ] ] in
+  Templates.Layout.default
+    ?flash_info
+    ?user
+    ~lang:"fr"
+    ~page_title:"Catégories"
+    Tyxml.Html.
+      [
+        div ~a:[ a_class [ "mb-2" ] ]
+          [
+            div ~a:[ a_class [ "content" ] ]
+              [
+                table
+                ~thead: hd
+                @@ List.map category_topics_count_line cnt_topics_by_categories
+              ]
+          ]
+      ]

--- a/app/views/category_views.ml
+++ b/app/views/category_views.ml
@@ -101,48 +101,25 @@ let all categories =
   @@ List.map category_line categories
 ;;
 
-let categories ?flash_info ?user categories =
-    Templates.Layout.default
-    ?flash_info
-    ?user
-    ~lang:"fr"
-    ~page_title:"Catégories"
-    Tyxml.Html.
-      [ div
-          [ h1 ~a:[ a_class [ "title" ] ] [ txt "Liste des catégories" ]
-          ; div
-              ~a:[ a_class [ "mb-6" ] ]
-              [ div
-                  [ h2
-                      ~a:[ a_class [ "title"; "is-4" ] ]
-                      [ txt "Catégories existantes" ]
-                  ; all categories
-                  ]
-              ]
-          ]
-      ]
-;;
-
-let category_topics_count_line cnt_topic_by_category =
-  let (category_name,category_descr,topic_cnt) = cnt_topic_by_category in
+let by_topic_count_line (name, desc, counter) =
   let open Tyxml.Html in
   tr [ 
     td [ 
-      p ~a:[a_class ["title is-4"]] [ txt category_name ];
-      p ~a:[a_class ["subtitle"]] [ txt category_descr ]
+      p ~a:[a_class ["title is-4"]] [ txt name ];
+      p ~a:[a_class ["subtitle"]] [ txt desc ]
     ]; 
     td [
-    if topic_cnt > 0 then
+    if counter > 0 then
         Templates.Util.a 
-          ~:Endpoints.Topic.by_category [txt (string_of_int topic_cnt)] category_name
+          ~:Endpoints.Topic.by_category [txt (string_of_int counter)] name
     else
-      txt (string_of_int topic_cnt)
+      txt (string_of_int counter)
     ]
   ]
 
 
 
-let categories_by_topics_count ?flash_info ?user cnt_topics_by_categories =
+let by_topics_count ?flash_info ?user cnt_topics_by_categories =
   let open Tyxml.Html in
   let hd = thead [ tr [ th [ txt "Catégories" ]; th [ txt "Nombre de topics" ] ] ] in
   Templates.Layout.default
@@ -158,7 +135,7 @@ let categories_by_topics_count ?flash_info ?user cnt_topics_by_categories =
               [
                 table
                 ~thead: hd
-                @@ List.map category_topics_count_line cnt_topics_by_categories
+                @@ List.map by_topic_count_line cnt_topics_by_categories
               ]
           ]
       ]

--- a/app/views/category_views.ml
+++ b/app/views/category_views.ml
@@ -1,0 +1,126 @@
+open Lib_service
+
+module Category = struct
+  let category_name_input =
+    let open Tyxml.Html in
+    div
+      ~a:[ a_class [ "field" ] ]
+      [ label
+          ~a:[ a_class [ "label" ]; a_label_for "create_category_name" ]
+          [ txt "Nom de la catégorie" ]
+      ; div
+          ~a:[ a_class [ "control" ] ]
+          [ input
+              ~a:
+                [ a_input_type `Text
+                ; a_placeholder "programmation"
+                ; a_id "create_category_name"
+                ; a_name "category_name"
+                ; a_class [ "input" ]
+                ]
+              ()
+          ]
+      ; p
+          ~a:[ a_class [ "help" ] ]
+          [ txt
+              "Nom de la catégorie, choisissez quelque chose de concis mais \
+               clair !"
+          ]
+      ]
+  ;;
+
+  let category_description_input =
+    let open Tyxml.Html in
+    div
+      ~a:[ a_class [ "field" ] ]
+      [ label
+          ~a:[ a_class [ "label" ]; a_label_for "create_category_description" ]
+          [ txt "Description de la catégorie" ]
+      ; div
+          ~a:[ a_class [ "control" ] ]
+          [ textarea
+              ~a:
+                [ a_placeholder
+                    "Catégorie relative aux conversations concernant la \
+                     programmation"
+                ; a_id "create_category_description"
+                ; a_name "category_description"
+                ; a_class [ "textarea"; "is-small" ]
+                ]
+              (txt "")
+          ]
+      ; p
+          ~a:[ a_class [ "help" ] ]
+          [ txt "Choisissez une description concise mais claire !" ]
+      ]
+  ;;
+
+  let submit_button =
+    let open Tyxml.Html in
+    div
+      ~a:[ a_class [ "field" ] ]
+      [ div
+          ~a:[ a_class [ "control" ] ]
+          [ input
+              ~a:
+                [ a_input_type `Submit
+                ; a_value "Valider !"
+                ; a_class [ "button"; "is-link" ]
+                ]
+              ()
+          ]
+      ]
+  ;;
+
+  let creation_form csrf_token =
+    Templates.Util.form
+      ~:Endpoints.Admin.new_category
+      ~csrf_token
+      [ category_name_input; category_description_input; submit_button ]
+  ;;
+
+  let category_line category =
+    let open Tyxml.Html in
+    let open Models.Category in
+    tr [ td [ txt category.name ]; td [ txt category.description ] ]
+  ;;
+
+  let all categories =
+    let open Tyxml.Html in
+    let hd = thead [ tr [ th [ txt "Nom" ]; th [ txt "Description" ] ] ] in
+    table
+      ~a:
+        [ a_class
+            [ "table"
+            ; "is-fullwidth"
+            ; "is-narrow"
+            ; "is-striped"
+            ; "is-bordered"
+            ]
+        ]
+      ~thead:hd
+    @@ List.map category_line categories
+  ;;
+end
+
+let categories ?flash_info ?user categories =
+    Templates.Layout.default
+    ?flash_info
+    ?user
+    ~lang:"fr"
+    ~page_title:"Catégories"
+    Tyxml.Html.
+      [ div
+          [ h1 ~a:[ a_class [ "title" ] ] [ txt "Liste des catégories" ]
+          ; div
+              ~a:[ a_class [ "mb-6" ] ]
+              [ div
+                  [ h2
+                      ~a:[ a_class [ "title"; "is-4" ] ]
+                      [ txt "Catégories existantes" ]
+                  ; Category.all categories
+                  ]
+              ]
+          ]
+      ]
+;;

--- a/app/views/category_views.mli
+++ b/app/views/category_views.mli
@@ -8,6 +8,8 @@ module Category :
       Models.Category.t -> [> Html_types.tr ] Tyxml_html.elt
     val all : Models.Category.t list -> [> Html_types.table ] Tyxml_html.elt
   end
+
+(** a view for listing all categories **)
 val categories :
   ?flash_info:Models.Flash_info.t ->
   ?user:Models.User.t ->

--- a/app/views/category_views.mli
+++ b/app/views/category_views.mli
@@ -1,16 +1,20 @@
-module Category :
-  sig
-    val category_name_input : [> Html_types.div ] Tyxml_html.elt
-    val category_description_input : [> Html_types.div ] Tyxml_html.elt
-    val submit_button : [> Html_types.div ] Tyxml_html.elt
-    val creation_form : string -> [> Html_types.form ] Tyxml_html.elt
-    val category_line :
-      Models.Category.t -> [> Html_types.tr ] Tyxml_html.elt
-    val all : Models.Category.t list -> [> Html_types.table ] Tyxml_html.elt
-  end
+val category_name_input : [> Html_types.div ] Tyxml_html.elt
+val category_description_input : [> Html_types.div ] Tyxml_html.elt
+val submit_button : [> Html_types.div ] Tyxml_html.elt
+val creation_form : string -> [> Html_types.form ] Tyxml_html.elt
+val category_line : Models.Category.t -> [> Html_types.tr ] Tyxml_html.elt
+val category_topics_count_line :
+  string * string * int -> [> Html_types.tr ] Tyxml_html.elt
+val all : Models.Category.t list -> [> Html_types.table ] Tyxml_html.elt
 
 (** a view for listing all categories **)
 val categories :
   ?flash_info:Models.Flash_info.t ->
   ?user:Models.User.t ->
   Models.Category.t list -> [> Html_types.html ] Tyxml_html.elt
+
+(** a view for listing all categories grouped by their number of topics **)
+val categories_by_topics_count :
+  ?flash_info:Models.Flash_info.t ->
+  ?user:Models.User.t ->
+  (string * string * int) list -> [> Html_types.html ] Tyxml_html.elt

--- a/app/views/category_views.mli
+++ b/app/views/category_views.mli
@@ -1,0 +1,14 @@
+module Category :
+  sig
+    val category_name_input : [> Html_types.div ] Tyxml_html.elt
+    val category_description_input : [> Html_types.div ] Tyxml_html.elt
+    val submit_button : [> Html_types.div ] Tyxml_html.elt
+    val creation_form : string -> [> Html_types.form ] Tyxml_html.elt
+    val category_line :
+      Models.Category.t -> [> Html_types.tr ] Tyxml_html.elt
+    val all : Models.Category.t list -> [> Html_types.table ] Tyxml_html.elt
+  end
+val categories :
+  ?flash_info:Models.Flash_info.t ->
+  ?user:Models.User.t ->
+  Models.Category.t list -> [> Html_types.html ] Tyxml_html.elt

--- a/app/views/category_views.mli
+++ b/app/views/category_views.mli
@@ -1,10 +1,4 @@
-val category_name_input : [> Html_types.div ] Tyxml_html.elt
-val category_description_input : [> Html_types.div ] Tyxml_html.elt
-val submit_button : [> Html_types.div ] Tyxml_html.elt
 val creation_form : string -> [> Html_types.form ] Tyxml_html.elt
-val category_line : Models.Category.t -> [> Html_types.tr ] Tyxml_html.elt
-val category_topics_count_line :
-  string * string * int -> [> Html_types.tr ] Tyxml_html.elt
 val all : Models.Category.t list -> [> Html_types.table ] Tyxml_html.elt
 
 (** a view for listing all categories **)

--- a/app/views/category_views.mli
+++ b/app/views/category_views.mli
@@ -1,14 +1,9 @@
 val creation_form : string -> [> Html_types.form ] Tyxml_html.elt
 val all : Models.Category.t list -> [> Html_types.table ] Tyxml_html.elt
 
-(** a view for listing all categories **)
-val categories :
-  ?flash_info:Models.Flash_info.t ->
-  ?user:Models.User.t ->
-  Models.Category.t list -> [> Html_types.html ] Tyxml_html.elt
 
 (** a view for listing all categories grouped by their number of topics **)
-val categories_by_topics_count :
+val by_topics_count :
   ?flash_info:Models.Flash_info.t ->
   ?user:Models.User.t ->
   (string * string * int) list -> [> Html_types.html ] Tyxml_html.elt

--- a/app/views/views.mli
+++ b/app/views/views.mli
@@ -6,3 +6,4 @@ module Global = Global_views
 module User = User_views
 module Topic = Topic_views
 module Admin = Admin_views
+module Category = Category_views


### PR DESCRIPTION
This PR add a page, accessible for all type of users, which list all the categories. As i don't really know what you expected this is a very minimal stuff, for example the view is basically a part of the `categories` view from `admin_views.ml`. I also create a `catefory_views.ml` file, and i move the Category module in it.

I'm looking forward your thoughts and suggestions !

Screenshots of the page : 

For an admin user

![Capture d’écran 2022-06-01 à 11 16 15](https://user-images.githubusercontent.com/10650661/171440235-971196b5-91bc-4d2b-b6fa-6b08e971e527.png)

For the others type of users : 

![Capture d’écran 2022-06-01 à 11 21 17](https://user-images.githubusercontent.com/10650661/171440476-6bd57431-b898-4571-8adc-825a84491782.png)

