### PR TITLE
Clever cloud deploy

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -4,13 +4,13 @@ on:
   push:
 
 env:
-  PGSQL_HOST: localhost
-  PGSQL_PORT: 5432
-  PGSQL_DB: postgres
-  PGSQL_USER: postgres
-  PGSQL_PASS: postgres
+  POSTGRESQL_ADDON_HOST: localhost
+  POSTGRESQL_ADDON_PORT: 5432
+  POSTGRESQL_ADDON_DB: postgres
+  POSTGRESQL_ADDON_USER: postgres
+  POSTGRESQL_ADDON_PASSWORD: postgres
   LOG_LEVEL: debug
-  PGSQL_CONNECTION_POOL: 20
+  POSTGRESQL_ADDON_CONNECTION_POOL: 20
 
 jobs:
   build_opam:

--- a/.test_env
+++ b/.test_env
@@ -1,7 +1,7 @@
-export PGSQL_HOST=localhost
-export PGSQL_PORT=5432
-export PGSQL_DB=muhokama_test
-export PGSQL_USER=muhokama
-export PGSQL_PASS=muhokama
-export LOG_LEVEL=debug
-export PGSQL_CONNECTION_POOL=20
+export POSTGRESQL_ADDON_HOST = localhost
+export POSTGRESQL_ADDON_PORT = 5432
+export POSTGRESQL_ADDON_DB = muhokama_test
+export POSTGRESQL_ADDON_USER = muhokama
+export POSTGRESQL_ADDON_PASSWORD = muhokama
+export LOG_LEVEL = debug
+export POSTGRESQL_ADDON_CONNECTION_POOL = 20

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,6 @@ FROM alpine:3 as final
 
 RUN apk add --no-cache libev-dev gmp-dev libpq-dev libressl-dev
 
-ENV LOG_LEVEL=info
-ENV PGSQL_CONNECTION_POOL=20
-
 EXPOSE 4000
 
 WORKDIR /app
@@ -32,5 +29,4 @@ ADD migrations /app/migrations
 
 COPY --from=builder /build/bin/muhokama.exe /usr/bin/muhokama.exe
 
-ENTRYPOINT [ "muhokama.exe" ]
-CMD [ "server.launch" ]
+CMD muhokama.exe db.migrate && muhokama.exe server.launch

--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ a password to be entered in a prompter, and two databases:
 The configuration is provisioned by environment variables:
 
 ``` sh
-export PGSQL_HOST=localhost
-export PGSQL_PORT=5432
-export PGSQL_DB=muhokama_dev
-export PGSQL_USER=muhokama
-export PGSQL_PASS=muhokama
+export POSTGRESQL_ADDON_HOST=localhost
+export POSTGRESQL_ADDON_PORT=5432
+export POSTGRESQL_ADDON_DB=muhokama_dev
+export POSTGRESQL_ADDON_USER=muhokama
+export POSTGRESQL_ADDON_PASSWORD=muhokama
 export LOG_LEVEL=debug
-export PGSQL_CONNECTION_POOL=20
+export POSTGRESQL_ADDON_CONNECTION_POOL=5
 ```
 
 ### Running integration test
@@ -80,3 +80,22 @@ subcommand can display its `man` page using the `--help` flag.
 | `./bin/muhokama.exe server.launch`| Starts the application on the default port (`4000`). It is possible to add the `--port X` flag to change this value. |
 | `./bin/muhokama.exe user.list` | Lists all registered users (regardless of their status) |
 | `./bin/muhokama.exe user.set-state -U USER_ID -S USER_STATE` | Changes the status (`inactive`, ` member`,  `moderator` `admin`) of a user via its ID ( `UUID` ). |
+
+### Deploy on clever cloud
+
+1. Create a docker application with a postgreSQL add-on
+2. Add the following environment variable to the docker application
+  - CC_DOCKER_EXPOSED_HTTP_PORT="4000"
+  - PGSQL_CONNECTION_POOL="5"
+
+> "5" is the maximum connections for free databases, you can adapt `PGSQL_CONNECTION_POOL` in accordance to the [pool of your plan](https://www.clever-cloud.com/doc/deploy/addon/postgresql/postgresql/#plans)
+
+3. In **Information** of the docker application, check the following options:
+  - Zero downtime deployment
+  - Enable dedicated build instance (Must be minimum S)
+  - Cancel ongoing deployment on new push
+  - Force HTTPS
+
+4. Add a git remote `git remote add clever <Deployment URL>`
+
+5. Push your first deployment `git push clever main:master`

--- a/lib/common/env.ml
+++ b/lib/common/env.ml
@@ -82,12 +82,12 @@ let validate =
   let open Validate in
   let open Free in
   make_environment
-  <$> required string "PGSQL_HOST"
-  <*> required (int & bounded_to 1 65535) "PGSQL_PORT"
-  <*> required string "PGSQL_DB"
-  <*> (optional int "PGSQL_CONNECTION_POOL" >? 20)
-  <*> required string "PGSQL_USER"
-  <*> required string "PGSQL_PASS"
+  <$> required string "POSTGRESQL_ADDON_HOST"
+  <*> required (int & bounded_to 1 65535) "POSTGRESQL_ADDON_PORT"
+  <*> required string "POSTGRESQL_ADDON_DB"
+  <*> (optional int "POSTGRESQL_ADDON_CONNECTION_POOL" >? 5)
+  <*> required string "POSTGRESQL_ADDON_USER"
+  <*> required string "POSTGRESQL_ADDON_PASSWORD"
   <*> (optional string_to_log "LOG_LEVEL" >? Logs.Info)
 ;;
 

--- a/migrations/11-enum-for-user-state.yml
+++ b/migrations/11-enum-for-user-state.yml
@@ -1,0 +1,16 @@
+up:
+  - |
+    UPDATE users
+    SET user_state = 'inactive'
+    WHERE user_state not in (VALUES ('member'),('inactive'),('administrator'),('moderator'))
+  - CREATE TYPE enum_member_state AS ENUM ('inactive','member', 'moderator', 'administrator')
+  - ALTER TABLE users ALTER COLUMN user_state DROP DEFAULT
+  - |
+    ALTER TABLE users ALTER COLUMN user_state TYPE enum_member_state 
+    USING user_state::text::enum_member_state
+  - ALTER TABLE users ALTER COLUMN user_state SET DEFAULT 'inactive'
+
+down:
+  - ALTER TABLE users ALTER COLUMN user_state TYPE VARCHAR(255)
+  - ALTER TABLE users ALTER COLUMN user_state SET DEFAULT 'inactive'
+  - DROP TYPE IF EXISTS enum_member_state


### PR DESCRIPTION
This PR add:
- modifications to allow deployment on clever cloud
  - Dockerfile run migration before starting the app
  - Database env vars are rename to accept postgres addon linking
- notice on readme to deploy on clever cloud

- replacement of varchar by an enum for user_state (not related to clever deployment but it's an improvement and serve as a test of migrations on clever). It is a separate commit.