### PR TITLE
fix #31 - Escaping HTML in messages

### DIFF
--- a/app/models/message_model.ml
+++ b/app/models/message_model.ml
@@ -12,6 +12,8 @@ type t =
 
 type creation_form = { creation_content : string }
 
+let map_content f message = { message with content = f message.content }
+
 let count =
   let query =
     (unit ->! int) {sql|

--- a/app/models/message_model.mli
+++ b/app/models/message_model.mli
@@ -42,6 +42,9 @@ val create
   -> Lib_db.t
   -> string Try.t Lwt.t
 
+(** Map a function over the message content. *)
+val map_content : (string -> string) -> t -> t
+
 (** Get a list of messages by topics ordered by creation date. *)
 val get_by_topic_id : (t -> 'a) -> string -> Lib_db.t -> 'a list Try.t Lwt.t
 

--- a/app/models/topic_model.ml
+++ b/app/models/topic_model.ml
@@ -72,6 +72,8 @@ module Showable = struct
     ; content : string
     }
 
+  let map_content f topic = { topic with content = f topic.content }
+
   let from_tuple
     ( id
     , ( category_name
@@ -157,9 +159,9 @@ let count_by_categories =
   let query =
     (unit ->* tup3 string string int)
       {sql|
-      SELECT 
+      SELECT
         category_name,
-        category_description, 
+        category_description,
         COUNT(*)
       FROM topics AS t
         INNER JOIN categories AS c ON t.category_id = c.category_id

--- a/app/models/topic_model.mli
+++ b/app/models/topic_model.mli
@@ -33,6 +33,7 @@ module Showable : sig
 
   val pp : t Fmt.t
   val equal : t -> t -> bool
+  val map_content : (string -> string) -> t -> t
 end
 
 (** {2 Form}

--- a/app/services/dune
+++ b/app/services/dune
@@ -5,6 +5,7 @@
  (libraries
   logs
   dream
+  omd
   tyxml
   fmt
   preface

--- a/app/services/topic_services.ml
+++ b/app/services/topic_services.ml
@@ -96,8 +96,14 @@ let show =
     ~succeed:(fun (user, topic, messages) request ->
       let flash_info = Flash_info.fetch request in
       let csrf_token = Dream.csrf_token request in
+      let html_topic =
+        Models.Topic.Showable.map_content markdown_to_html topic
+      in
+      let html_messages =
+        List.map (Models.Message.map_content markdown_to_html) messages
+      in
       let view =
-        Views.Topic.show ?flash_info ~csrf_token ~user topic messages
+        Views.Topic.show ?flash_info ~csrf_token ~user html_topic html_messages
       in
       Dream.html @@ from_tyxml view)
     ~failure:(fun err request ->

--- a/app/services/util.mli
+++ b/app/services/util.mli
@@ -60,3 +60,6 @@ module Auth : sig
   (** Resolves the current connected user.*)
   val get_connected_user_id : Dream.request -> string option
 end
+
+(** Process a text string into HTML using [OMD]. *)
+val markdown_to_html : string -> string

--- a/app/views/admin_views.ml
+++ b/app/views/admin_views.ml
@@ -44,8 +44,8 @@ module List_moderable = struct
     let open Tyxml.Html in
     let Models.User.{ email; name; state; _ } = user in
     tr
-      [ td [ txt name ]
-      ; td [ txt email ]
+      [ td [ txt @@ Lib_common.Html.escape_special_chars name ]
+      ; td [ txt @@ Lib_common.Html.escape_special_chars email ]
       ; td
           ~a:[ a_class [ "has-text-centered" ] ]
           [ Templates.Component.user_state_tag state ]

--- a/app/views/category_views.ml
+++ b/app/views/category_views.ml
@@ -81,7 +81,10 @@ let creation_form csrf_token =
 let category_line category =
   let open Tyxml.Html in
   let open Models.Category in
-  tr [ td [ txt category.name ]; td [ txt category.description ] ]
+  tr
+    [ td [ txt @@ Lib_common.Html.escape_special_chars category.name ]
+    ; td [ txt @@ Lib_common.Html.escape_special_chars category.description ]
+    ]
 ;;
 
 let all categories =

--- a/app/views/dune
+++ b/app/views/dune
@@ -2,4 +2,4 @@
  (name views)
  (package muhokama)
  (modules_without_implementation views)
- (libraries dream fmt omd preface lib_common models templates))
+ (libraries dream fmt preface lib_common models templates))

--- a/app/views/topic_views.ml
+++ b/app/views/topic_views.ml
@@ -133,7 +133,8 @@ module List = struct
           [ Templates.Util.a
               ~:Endpoints.Topic.by_category
               ~a:[ a_class [ "button"; "is-info"; "is-pulled-right" ] ]
-              [ txt topic.category_name ]
+              [ txt @@ Lib_common.Html.escape_special_chars topic.category_name
+              ]
               topic.category_name
           ]
       ]
@@ -154,7 +155,7 @@ module Show = struct
   let show_content user_name user_email creation_date message =
     let open Tyxml.Html in
     (* FIXME: Maybe get rid of Tyxml.Html.Unsafe*)
-    let message_html = Omd.of_string message |> Omd.to_html |> Unsafe.data in
+    let message_html = Unsafe.data message in
     div
       ~a:[ a_class [ "media" ] ]
       [ div

--- a/lib/common/html.ml
+++ b/lib/common/html.ml
@@ -1,0 +1,20 @@
+let escape_special_chars subject =
+  let length = String.length subject in
+  let buffer = Buffer.create length in
+  let rec aux i =
+    if i < length
+    then (
+      let () =
+        match String.get subject i with
+        | '<' -> Buffer.add_string buffer "&lt;"
+        | '>' -> Buffer.add_string buffer "&gt;"
+        | '&' -> Buffer.add_string buffer "&amp;"
+        | '\'' -> Buffer.add_string buffer "&apos;"
+        | '\"' -> Buffer.add_string buffer "&quot;"
+        | c -> Buffer.add_char buffer c
+      in
+      aux (i + 1))
+  in
+  let () = aux 0 in
+  buffer |> Buffer.to_bytes |> Bytes.to_string
+;;

--- a/lib/common/html.mli
+++ b/lib/common/html.mli
@@ -1,0 +1,5 @@
+(** Some helpers to deal with HTML. *)
+
+(** Escape html special chars from a string. The table of special chars come
+    from: https://www.php.net/manual/fr/function.htmlspecialchars.php *)
+val escape_special_chars : string -> string

--- a/test/unit/common/html_test.ml
+++ b/test/unit/common/html_test.ml
@@ -1,0 +1,70 @@
+open Lib_common
+open Lib_test
+
+let test_escape_special_char_without_special_char =
+  test
+    ~about:"escape_special_chars"
+    ~desc:"when there is not special chars, it should preserve the string"
+    (fun () ->
+    let subject =
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce \
+       tristique commodo auctor. Nam faucibus ultrices pulvinar. Aenean \
+       vehicula massa velit, at euismod dui sollicitudin et. Integer et orci \
+       tempor, eleifend felis et, ultricies lorem. Quisque dictum nunc \
+       malesuada metus convallis, a efficitur ex lacinia. Nam sit amet \
+       accumsan eros. Nulla rhoncus massa id enim egestas, ac venenatis augue \
+       molestie. Morbi ultrices eget augue vitae ultrices. Mauris tempus justo \
+       et nisi malesuada, in maximus metus ultricies. Proin quis erat quis \
+       lectus aliquet gravida. Maecenas mattis sit amet lacus sed vulputate. \
+       Ut mollis nibh arcu, ac vestibulum orci ullamcorper eu. Donec a \
+       lobortis ante. Orci varius natoque penatibus et magnis dis parturient \
+       montes, nascetur ridiculus mus."
+    in
+    let expected = subject
+    and computed = Html.escape_special_chars subject in
+    same Alcotest.string ~expected ~computed)
+;;
+
+let test_escape_special_char_with_chars =
+  test
+    ~about:"escape_special_chars"
+    ~desc:"when there is not special chars, it should preserve the string"
+    (fun () ->
+    let subject =
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce \
+       <strong>tristique commodo auctor. Nam faucibus ultrices pulvinar. \
+       </strong>Aenean vehicula massa velit, <i>at euismod 'dui sollicitudin \
+       e'</i>t. Integer et \"orci tempor, eleifend felis\" et, ultricies \
+       lorem. Quisque dictum nunc malesuada metus convallis, a efficitur ex \
+       lacinia. Nam sit amet accumsan eros. Nulla rhoncus massa id enim \
+       egestas, ac venenatis augue molestie. Morbi ultrices eget augue vitae \
+       ultrices. Mauris tempus justo et nisi malesuada, in maximus metus \
+       ultricies. Proin quis erat quis lectus aliquet gravida. Maecenas mattis \
+       sit amet lacus sed vulputate. Ut mollis nibh arcu, ac vestibulum orci \
+       ullamcorper eu. Donec a lobortis ante. Orci varius natoque penatibus et \
+       magnis dis parturient montes, nascetur ridiculus mus."
+    in
+    let expected =
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce \
+       &lt;strong&gt;tristique commodo auctor. Nam faucibus ultrices pulvinar. \
+       &lt;/strong&gt;Aenean vehicula massa velit, &lt;i&gt;at euismod \
+       &apos;dui sollicitudin e&apos;&lt;/i&gt;t. Integer et &quot;orci \
+       tempor, eleifend felis&quot; et, ultricies lorem. Quisque dictum nunc \
+       malesuada metus convallis, a efficitur ex lacinia. Nam sit amet \
+       accumsan eros. Nulla rhoncus massa id enim egestas, ac venenatis augue \
+       molestie. Morbi ultrices eget augue vitae ultrices. Mauris tempus justo \
+       et nisi malesuada, in maximus metus ultricies. Proin quis erat quis \
+       lectus aliquet gravida. Maecenas mattis sit amet lacus sed vulputate. \
+       Ut mollis nibh arcu, ac vestibulum orci ullamcorper eu. Donec a \
+       lobortis ante. Orci varius natoque penatibus et magnis dis parturient \
+       montes, nascetur ridiculus mus."
+    and computed = Html.escape_special_chars subject in
+    same Alcotest.string ~expected ~computed)
+;;
+
+let cases =
+  ( "Html"
+  , [ test_escape_special_char_without_special_char
+    ; test_escape_special_char_with_chars
+    ] )
+;;

--- a/test/unit/common/html_test.mli
+++ b/test/unit/common/html_test.mli
@@ -1,0 +1,1 @@
+val cases : string * unit Alcotest.test_case list

--- a/test/unit/common/lib_common_test.ml
+++ b/test/unit/common/lib_common_test.ml
@@ -1,2 +1,2 @@
-let suites = [ Validate_test.cases; Assoc_test.cases ]
+let suites = [ Validate_test.cases; Assoc_test.cases; Html_test.cases ]
 let () = Alcotest.run "Lib_common" suites


### PR DESCRIPTION
HTML blocks are supported by OMD, so before producing the HTML, we go through the syntax tree and replace all HTML occurrences with CODE occurrences (in block and inline).
(cc @leonard-IMBERT)