### PR TITLE
Use the category name instead of topic count as a link - fix #43

### DIFF
--- a/app/models/topic_model.ml
+++ b/app/models/topic_model.ml
@@ -199,7 +199,9 @@ let count_by_categories =
         category_description,
         COUNT(*)
       FROM topics AS t
-        INNER JOIN categories AS c ON t.category_id = c.category_id
+        INNER JOIN categories AS c
+          ON t.category_id = c.category_id
+      WHERE t.topic_archived = FALSE
       GROUP BY c.category_name, c.category_description
       ORDER BY c.category_name
     |sql}
@@ -343,9 +345,10 @@ let list_by_category category_name callback =
             t.topic_title,
             t.topic_counter
           FROM topics AS t
-            INNER JOIN categories AS c ON t.category_id = c.category_id
+            INNER JOIN categories AS c
+              ON t.category_id = c.category_id
             INNER JOIN users AS u ON t.user_id = u.user_id
-          WHERE c.category_name = ?
+          WHERE c.category_name = ? AND t.topic_archived = FALSE
           ORDER BY topic_update_date DESC
       |sql}
   in

--- a/app/views/category_views.ml
+++ b/app/views/category_views.ml
@@ -103,18 +103,12 @@ let by_topic_count_line (name, desc, counter) =
   let open Tyxml.Html in
   tr
     [ td
-        [ p ~a:[ a_class [ "title is-4" ] ] [ txt name ]
+        [ p
+            ~a:[ a_class [ "title is-4" ] ]
+            [ Templates.Util.a ~:Endpoints.Topic.by_category [ txt name ] name ]
         ; p ~a:[ a_class [ "subtitle" ] ] [ txt desc ]
         ]
-    ; td
-        [ (if counter > 0
-          then
-            Templates.Util.a
-              ~:Endpoints.Topic.by_category
-              [ txt (string_of_int counter) ]
-              name
-          else txt (string_of_int counter))
-        ]
+    ; td [ txt (string_of_int counter) ]
     ]
 ;;
 


### PR DESCRIPTION
I think it's better because there's more text to be clicked that way. An even better solution IMO would be to make the whole row clickable but I'm not sure how to do that.

![2](https://user-images.githubusercontent.com/7795522/197059139-9ef711d3-bfe0-440c-9111-366b2305d33e.png)
