### PR TITLE
Database errors

### DIFF
--- a/lib/common/dune
+++ b/lib/common/dune
@@ -2,6 +2,6 @@
  (name lib_common)
  (package muhokama)
  (modules_without_implementation intf)
- (libraries lwt fmt logs yojson preface)
+ (libraries lwt fmt logs yojson preface str)
  (preprocess
   (pps ppx_yojson_conv)))

--- a/lib/common/string.ml
+++ b/lib/common/string.ml
@@ -1,0 +1,4 @@
+include Stdlib.String
+
+let replace ~pattern ~by str =
+  Str.global_replace (Str.regexp pattern) by str

--- a/lib/common/string.mli
+++ b/lib/common/string.mli
@@ -1,0 +1,3 @@
+include module type of Stdlib.String
+
+val replace : pattern:string -> by:string -> string -> string

--- a/lib/db/dune
+++ b/lib/db/dune
@@ -8,4 +8,5 @@
   caqti-driver-postgresql
   fmt
   lib_common
-  preface))
+  preface
+  dream))

--- a/lib/db/lib_db.ml
+++ b/lib/db/lib_db.ml
@@ -10,8 +10,9 @@ let try_ request_expr =
   >>= function
   | Ok result -> return_ok result
   | Error err ->
-    let message = Caqti_error.show err in
-    return Error.(to_try @@ Database message)
+    let message = Caqti_error.show err |> String.replace ~pattern:"\n" ~by:"|" in
+    Dream.error (fun log -> log "%s" message);
+    return Error.(to_try @@ Database "A database error has occurred")
 ;;
 
 let make_uri_with ~user ~password ~host ~port ~database =


### PR DESCRIPTION
Hi!

I'd like to fix https://github.com/xvw/muhokama/issues/57 but I'm not quite sure what we should display to the user instead. I am not yet familiar with Caqti errors, but I believe the actual error message 

> ERROR: invalid input syntax for type uuid: "03c17d2e-6e82-4ef3-9348-g714a129001"

could help them know what they did wrong. Should I display it?

To reproduce the error, try using an incorrect UID, e.g., http://localhost:4000/topic/show/03c17d2e-6e82-4ef3-9348-g714a1290019 (character `g` is invalid here).

Edit : also, just to be sure: I don't need to add any dependency to the .opam file, as Str is already in Stdlib, right? And CI is failing on this because I seem to have an issue with ocamlformat at the moment.