### PR TITLE
Fix the date of publication from UTC+2 UTC+1

### DIFF
--- a/app/templates/util.ml
+++ b/app/templates/util.ml
@@ -16,7 +16,7 @@ let csrf_input value =
 
 let format_date date =
   let (year, month, day), ((hour, min, _), _) =
-    Ptime.to_date_time ~tz_offset_s:(3600 * 2) date
+    Ptime.to_date_time ~tz_offset_s:(3600 * Lib_common.Date.offset date) date
   in
   Fmt.str "%04d-%02d-%02d à %02d:%02d" year month day hour min
 ;;

--- a/lib/common/date.ml
+++ b/lib/common/date.ml
@@ -1,0 +1,28 @@
+module Int_map = Map.Make (Int)
+
+let db =
+  let seq =
+    [ 2020, ((29, 3), (25, 10))
+    ; 2021, ((28, 3), (31, 10))
+    ; 2022, ((27, 3), (30, 10))
+    ; 2023, ((26, 3), (29, 10))
+    ; 2024, ((31, 3), (27, 10))
+    ; 2025, ((30, 3), (26, 10))
+    ]
+    |> List.to_seq
+  in
+  Int_map.of_seq seq
+;;
+
+let offset date =
+  let result =
+    let open Preface.Option.Monad in
+    let year, _, _ = Ptime.to_date date in
+    let* (s_day, s_month), (w_day, w_month) = Int_map.find_opt year db in
+    let* s_date = Ptime.of_date_time ((year, s_month, s_day), ((3, 0, 0), 0)) in
+    let+ w_date = Ptime.of_date_time ((year, w_month, w_day), ((3, 0, 0), 0)) in
+    if Ptime.is_later ~than:s_date date && Ptime.is_earlier ~than:w_date date
+    then 2
+    else 1
+  in Option.value ~default:1 result
+;;

--- a/lib/common/date.ml
+++ b/lib/common/date.ml
@@ -24,5 +24,6 @@ let offset date =
     if Ptime.is_later ~than:s_date date && Ptime.is_earlier ~than:w_date date
     then 2
     else 1
-  in Option.value ~default:1 result
+  in
+  Option.value ~default:1 result
 ;;

--- a/lib/common/date.mli
+++ b/lib/common/date.mli
@@ -1,0 +1,1 @@
+val offset : Ptime.t -> Ptime.tz_offset_s

--- a/lib/common/dune
+++ b/lib/common/dune
@@ -2,6 +2,6 @@
  (name lib_common)
  (package muhokama)
  (modules_without_implementation intf)
- (libraries lwt fmt logs yojson preface)
+ (libraries lwt fmt logs yojson preface ptime)
  (preprocess
   (pps ppx_yojson_conv)))

--- a/test/unit/common/date_test.ml
+++ b/test/unit/common/date_test.ml
@@ -1,0 +1,33 @@
+open Lib_test
+
+let test_offset_date =
+  test
+    ~about:"test_winter_date"
+    ~desc:
+      "Test that for winter date the time zone it UTC+1 and that for summer \
+       date the time zone is UTC+2"
+    (fun () ->
+      [ ((2024, 02, 06), (16, 32, 15)), 1
+      ; ((2020, 01, 09), (02, 43, 33)), 1
+      ; ((2020, 05, 08), (02, 45, 03)), 2
+      ; ((2020, 11, 29), (04, 13, 30)), 1
+      ; ((2021, 01, 11), (05, 18, 17)), 1
+      ; ((2021, 11, 26), (05, 52, 13)), 1
+      ; ((2022, 03, 18), (06, 40, 02)), 1
+      ; ((2022, 09, 03), (08, 55, 01)), 2
+      ; ((2024, 06, 11), (11, 13, 52)), 2
+      ; ((2024, 11, 04), (11, 47, 59)), 1
+      ; ((2024, 11, 11), (12, 55, 59)), 1
+      ; ((2024, 12, 20), (13, 00, 26)), 1
+      ; ((2025, 08, 06), (14, 47, 27)), 2
+      ; ((2025, 08, 18), (22, 16, 14)), 2
+      ; ((2025, 08, 29), (23, 13, 34)), 2
+      ; ((2025, 08, 31), (23, 39, 47)), 2
+      ]
+      |> List.iter (fun ((date, time), expeted_tz) ->
+          let computed = Ptime.of_date_time (date, (time, 0)) |> Option.map Lib_common.Date.offset
+          and expected = Some expeted_tz in
+          Alcotest.(check (option int)) "Are all the timezone correct" computed expected))
+;;
+
+let cases = "Date validation", [ test_offset_date ]

--- a/test/unit/common/date_test.ml
+++ b/test/unit/common/date_test.ml
@@ -7,27 +7,32 @@ let test_offset_date =
       "Test that for winter date the time zone it UTC+1 and that for summer \
        date the time zone is UTC+2"
     (fun () ->
-      [ ((2024, 02, 06), (16, 32, 15)), 1
-      ; ((2020, 01, 09), (02, 43, 33)), 1
-      ; ((2020, 05, 08), (02, 45, 03)), 2
-      ; ((2020, 11, 29), (04, 13, 30)), 1
-      ; ((2021, 01, 11), (05, 18, 17)), 1
-      ; ((2021, 11, 26), (05, 52, 13)), 1
-      ; ((2022, 03, 18), (06, 40, 02)), 1
-      ; ((2022, 09, 03), (08, 55, 01)), 2
-      ; ((2024, 06, 11), (11, 13, 52)), 2
-      ; ((2024, 11, 04), (11, 47, 59)), 1
-      ; ((2024, 11, 11), (12, 55, 59)), 1
-      ; ((2024, 12, 20), (13, 00, 26)), 1
-      ; ((2025, 08, 06), (14, 47, 27)), 2
-      ; ((2025, 08, 18), (22, 16, 14)), 2
-      ; ((2025, 08, 29), (23, 13, 34)), 2
-      ; ((2025, 08, 31), (23, 39, 47)), 2
-      ]
-      |> List.iter (fun ((date, time), expeted_tz) ->
-          let computed = Ptime.of_date_time (date, (time, 0)) |> Option.map Lib_common.Date.offset
-          and expected = Some expeted_tz in
-          Alcotest.(check (option int)) "Are all the timezone correct" computed expected))
+    [ ((2024, 02, 06), (16, 32, 15)), 1
+    ; ((2020, 01, 09), (02, 43, 33)), 1
+    ; ((2020, 05, 08), (02, 45, 03)), 2
+    ; ((2020, 11, 29), (04, 13, 30)), 1
+    ; ((2021, 01, 11), (05, 18, 17)), 1
+    ; ((2021, 11, 26), (05, 52, 13)), 1
+    ; ((2022, 03, 18), (06, 40, 02)), 1
+    ; ((2022, 09, 03), (08, 55, 01)), 2
+    ; ((2024, 06, 11), (11, 13, 52)), 2
+    ; ((2024, 11, 04), (11, 47, 59)), 1
+    ; ((2024, 11, 11), (12, 55, 59)), 1
+    ; ((2024, 12, 20), (13, 00, 26)), 1
+    ; ((2025, 08, 06), (14, 47, 27)), 2
+    ; ((2025, 08, 18), (22, 16, 14)), 2
+    ; ((2025, 08, 29), (23, 13, 34)), 2
+    ; ((2025, 08, 31), (23, 39, 47)), 2
+    ]
+    |> List.iter (fun ((date, time), expeted_tz) ->
+         let computed =
+           Ptime.of_date_time (date, (time, 0))
+           |> Option.map Lib_common.Date.offset
+         and expected = Some expeted_tz in
+         Alcotest.(check (option int))
+           "Are all the timezone correct"
+           computed
+           expected))
 ;;
 
 let cases = "Date validation", [ test_offset_date ]

--- a/test/unit/common/date_test.mli
+++ b/test/unit/common/date_test.mli
@@ -1,0 +1,1 @@
+val cases : string * unit Alcotest.test_case list

--- a/test/unit/common/dune
+++ b/test/unit/common/dune
@@ -1,3 +1,3 @@
 (test
  (name lib_common_test)
- (libraries alcotest lib_common lib_test))
+ (libraries alcotest lib_common lib_test ptime))

--- a/test/unit/common/lib_common_test.ml
+++ b/test/unit/common/lib_common_test.ml
@@ -1,2 +1,5 @@
-let suites = [ Validate_test.cases; Assoc_test.cases; Html_test.cases ]
+let suites =
+  [ Validate_test.cases; Assoc_test.cases; Html_test.cases; Date_test.cases ]
+;;
+
 let () = Alcotest.run "Lib_common" suites


### PR DESCRIPTION
This is a hardfix of #61, waiting for a more complete fix.